### PR TITLE
[DO NOT MERGE] Circle CI Build Demonstration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,30 @@ jobs:
       - run:
           name: Generate ProtoBuf Files
           command: ./gen-swift
+      # E: iOS Code Signing Prep
+      - run:
+          name: Generate Certificate(s)
+          # CIDEV_CERT=<secret>
+          command: test "$CIDEV_CERT" && base64 --decode >'cidev.p12' <<< $CIDEV_CERT
+      - run:
+          name: Install Certificate(s)
+          # CIDEV_PASSWD=<secret>
+          command: fastlane gen_ci_cert
+      - run:
+          name: Generate Provisioning
+          # CIDEV_PROV=<secret>
+          command: test "$CIDEV_PROV" && base64 --decode >'cidev_prov.mobileprovision' <<< $CIDEV_PROV
+      - run:
+          name: Ensure Provisioning Directory
+          command: mkdir -pv "$HOME/Library/MobileDevice/Provisioning Profiles/"
+      - run:
+          name: Install Provisioning
+          # CIDEV_PROV_UUID
+          command: test "$CIDEV_PROV_UUID" && cp 'cidev_prov.mobileprovision' "$HOME/Library/MobileDevice/Provisioning Profiles/$CIDEV_PROV_UUID.mobileprovision"
+      # F: Build
+      - run:
+          name: Build
+          command: xcodebuild -workspace HGCApp.xcworkspace -scheme HGCApp_Debug
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,26 @@
 # .circleci/config.yml
 version: 2
 jobs:
-  build-and-test:
+  build-and-unit-test:
     macos:
       xcode: "11.0.0"
     environment:
       FL_OUTPUT_DIR: output
     steps:
+      # A: Code checkout
       - checkout
+      # B: Homebrew
       - run:
-          name: Install CocoaPods Gem
-          command: gem install cocoapods
+          name: Record Homebrew Version
+          command: brew --version
       - run:
-          name: Fetch CocoaPods Specs
-          command: |
-            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
-
+          name: Record Homebrew Formulae
+          command: brew list
+          # Available by 2.1.15
+          # command: brew list --verbose
+      - run:
+          name: Record Homebrew Leaves
+          command: brew leaves
       - run:
           name: Install ProtoBuf
           command: brew install protobuf
@@ -23,22 +28,11 @@ jobs:
           name: Install Swift-protobuf
           command: brew install swift-protobuf
       - run:
-          name: Install APp
-          command: pod install --verbose
-      # - run:
-      #     name: Build and run tests
-      #     command: fastlane scan
-      #     environment:
-      #       SCAN_DEVICE: iPhone 8
-      #       SCAN_SCHEME: WebTests
-
-      - store_test_results:
-          path: output/scan
-      - store_artifacts:
-          path: output
+          name: Install gRPC-Swift
+          command: brew install grpc-swift
 
 workflows:
   version: 2
-  build-and-test:
+  build:
     jobs:
-      - build-and-test
+      - build-and-unit-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,23 @@ jobs:
       - run:
           name: Install gRPC-Swift
           command: brew install grpc-swift
+      # C: Cocoapods
+      - run:
+          name: Record Gem Version
+          command: gem --version
+      - run:
+          name: Install Cocoapods Gem
+          command: gem install cocoapods
+      - run:
+          name: Record Cocoapods Version
+          command: pod --version
+      - run:
+          name: Fetch CocoaPods Specs
+          command: |
+            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+      - run:
+          name: Install Dependencies in CocoaPods
+          command: pod install --verbose
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,10 @@ jobs:
       - run:
           name: Install Dependencies in CocoaPods
           command: pod install --verbose
+      # D: Generate Swift ProtoBuf Integration Files
+      - run:
+          name: Generate ProtoBuf Files
+          command: ./gen-swift
 
 workflows:
   version: 2

--- a/HGCApp.xcodeproj/project.pbxproj
+++ b/HGCApp.xcodeproj/project.pbxproj
@@ -291,6 +291,7 @@
 
 /* Begin PBXFileReference section */
 		0AD87E7F256A51BD770B1BF0 /* Pods-HGCAppUITests.release_prod_oc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HGCAppUITests.release_prod_oc.xcconfig"; path = "Pods/Target Support Files/Pods-HGCAppUITests/Pods-HGCAppUITests.release_prod_oc.xcconfig"; sourceTree = "<group>"; };
+		0B18A2FE2379B8590074A651 /* HGCAppDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HGCAppDebug.entitlements; sourceTree = "<group>"; };
 		10905C2F9BF793846D9D8B8C /* Pods-HGCApp.release_dev_oc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HGCApp.release_dev_oc.xcconfig"; path = "Pods/Target Support Files/Pods-HGCApp/Pods-HGCApp.release_dev_oc.xcconfig"; sourceTree = "<group>"; };
 		1808C31922488D8200FD7F45 /* ExchangeRate.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExchangeRate.pb.swift; sourceTree = "<group>"; };
 		1808C31A22488D8300FD7F45 /* TransactionBody.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionBody.pb.swift; sourceTree = "<group>"; };
@@ -1103,6 +1104,7 @@
 		35B8ABBC1F9E5642003E4F57 /* HGCApp */ = {
 			isa = PBXGroup;
 			children = (
+				0B18A2FE2379B8590074A651 /* HGCAppDebug.entitlements */,
 				1851A6482156240000752A80 /* Config.swift */,
 				35B8ABBD1F9E5642003E4F57 /* AppDelegate.swift */,
 				18EE0AB0225F6CF800FCFA5B /* Crypto */,
@@ -1868,6 +1870,151 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		0B18A2FA2379B8060074A651 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APP_BUNDLE_ID = com.hedera.wallet.dev;
+				APP_DISPLAY_NAME = "Dev Hedera Wallet";
+				BRANCHIO_TEST_DOMAIN_PREFIX = "test-";
+				BUILD_NUM = 126;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CUSTOM_URL_SCHEMA = hgcdev;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+					"$(HGCAPP_ENVIRONMENT)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HGCAPP_ENVIRONMENT = DEVELOPMENT;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		0B18A2FB2379B8060074A651 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7900765FDCE4C72C6CFC503B /* Pods-HGCApp.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = HGCApp/HGCAppDebug.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = Q8VBEXUY2V;
+				ENABLE_BITCODE = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"${PODS_ROOT}/Headers/Public\"",
+					"\"${PODS_ROOT}/Headers/Public/ABPadLockScreen\"",
+					"\"${PODS_ROOT}/Headers/Public/CocoaAsyncSocket\"",
+					"\"${PODS_ROOT}/Headers/Public/Crashlytics\"",
+					"\"${PODS_ROOT}/Headers/Public/Fabric\"",
+					"\"${PODS_ROOT}/Headers/Public/LGSideMenuController\"",
+					"\"${PODS_ROOT}/Headers/Public/MBProgressHUD\"",
+					"\"${PODS_ROOT}/Headers/Public/MTBBarcodeScanner\"",
+					"\"${PODS_ROOT}/Headers/Public/NSDate+TimeAgo\"",
+					"\"${PODS_ROOT}/Headers/Public/OpenSSL-Universal\"",
+					"$(SRCROOT)/HGCApp/'Utilities & Managers'/Keys/ED25519/CEd25519/include",
+				);
+				INFOPLIST_FILE = "$(SRCROOT)/HGCApp/Supporting Files/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.github.arensic.hbar-wallet-ios";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "HBAR Wallet Development";
+				SWIFT_OBJC_BRIDGING_HEADER = "HGCApp/Supporting Files/HGCApp-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		0B18A2FC2379B8060074A651 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BC427FB8B3BE1B226EC5DDDC /* Pods-HGCAppTests.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = Y6G863755L;
+				INFOPLIST_FILE = tests/HGCAppTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = hgc.HGCAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "HGCApp/Supporting Files/HGCApp-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/HGCApp.app/HGCApp";
+			};
+			name = Debug;
+		};
+		0B18A2FD2379B8060074A651 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = CAFF7BC70E9B76A911C180A0 /* Pods-HGCAppUITests.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
+				INFOPLIST_FILE = tests/HGCAppUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = hgc.HGCAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = HGCApp;
+			};
+			name = Debug;
+		};
 		180E7445232A55CF00D88BB6 /* Release_Dev */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2302,6 +2449,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				35B8ABE01F9E5642003E4F57 /* Debug_Dev */,
+				0B18A2FA2379B8060074A651 /* Debug */,
 				180E7445232A55CF00D88BB6 /* Release_Dev */,
 				18BF967421C225C300055B2A /* Release_Prod */,
 			);
@@ -2312,6 +2460,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				35B8ABE31F9E5642003E4F57 /* Debug_Dev */,
+				0B18A2FB2379B8060074A651 /* Debug */,
 				180E7446232A55CF00D88BB6 /* Release_Dev */,
 				18BF967521C225C300055B2A /* Release_Prod */,
 			);
@@ -2322,6 +2471,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				35B8ABE61F9E5642003E4F57 /* Debug_Dev */,
+				0B18A2FC2379B8060074A651 /* Debug */,
 				180E7447232A55CF00D88BB6 /* Release_Dev */,
 				18BF967621C225C300055B2A /* Release_Prod */,
 			);
@@ -2332,6 +2482,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				35B8ABE91F9E5642003E4F57 /* Debug_Dev */,
+				0B18A2FD2379B8060074A651 /* Debug */,
 				180E7448232A55CF00D88BB6 /* Release_Dev */,
 				18BF967721C225C300055B2A /* Release_Prod */,
 			);

--- a/HGCApp.xcodeproj/xcshareddata/xcschemes/HGCApp_Debug.xcscheme
+++ b/HGCApp.xcodeproj/xcshareddata/xcschemes/HGCApp_Debug.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1120"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "35B8ABB91F9E5642003E4F57"
+               BuildableName = "HGCApp.app"
+               BlueprintName = "HGCApp"
+               ReferencedContainer = "container:HGCApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug_Dev"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "35B8ABB91F9E5642003E4F57"
+            BuildableName = "HGCApp.app"
+            BlueprintName = "HGCApp"
+            ReferencedContainer = "container:HGCApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release_Dev"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "35B8ABB91F9E5642003E4F57"
+            BuildableName = "HGCApp.app"
+            BlueprintName = "HGCApp"
+            ReferencedContainer = "container:HGCApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug_Dev">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release_Dev"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/HGCApp/HGCAppDebug.entitlements
+++ b/HGCApp/HGCAppDebug.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,6 +16,18 @@
 default_platform(:ios)
 
 platform :ios do
+
+  desc "Generate signing certificates on Circle CI"
+  lane :gen_ci_cert do
+    setup_circle_ci
+    import_certificate(
+      keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
+      keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"],
+      certificate_path: 'cidev.p12',
+      certificate_password: ENV["CIDEV_PASSWD"] || "default"
+    )
+  end
+
   desc "Push a new beta build to OC TestFlight"
   lane :beta_dev do
     build_app(workspace: "HGCApp.xcworkspace", scheme: "HGCApp_Dev")


### PR DESCRIPTION
This branch demonstrates how we can build with iOS code signing on Circle CI.  The final commit adds a new scheme and build configuration so that I can sign with my own development certificate and provisioning profile.  If we were to proceed, a Hedera development certificate and provisioning profile would need to be issued.

Epic: #186 