### PR TITLE
UI Test: Add new onboard existing case

### DIFF
--- a/HGCApp.xcodeproj/project.pbxproj
+++ b/HGCApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B0ADD4223A5735D0069AD41 /* OnboardExistingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B0ADD4123A5735D0069AD41 /* OnboardExistingTests.swift */; };
 		1808C31B22488D8300FD7F45 /* ExchangeRate.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1808C31922488D8200FD7F45 /* ExchangeRate.pb.swift */; };
 		1808C31C22488D8300FD7F45 /* TransactionBody.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1808C31A22488D8300FD7F45 /* TransactionBody.pb.swift */; };
 		1815081921858B3000890123 /* IPUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1815080B21858B3000890123 /* IPUtility.swift */; };
@@ -294,6 +295,7 @@
 
 /* Begin PBXFileReference section */
 		0AD87E7F256A51BD770B1BF0 /* Pods-HGCAppUITests.release_prod_oc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HGCAppUITests.release_prod_oc.xcconfig"; path = "Pods/Target Support Files/Pods-HGCAppUITests/Pods-HGCAppUITests.release_prod_oc.xcconfig"; sourceTree = "<group>"; };
+		0B0ADD4123A5735D0069AD41 /* OnboardExistingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardExistingTests.swift; sourceTree = "<group>"; };
 		10905C2F9BF793846D9D8B8C /* Pods-HGCApp.release_dev_oc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HGCApp.release_dev_oc.xcconfig"; path = "Pods/Target Support Files/Pods-HGCApp/Pods-HGCApp.release_dev_oc.xcconfig"; sourceTree = "<group>"; };
 		1808C31922488D8200FD7F45 /* ExchangeRate.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExchangeRate.pb.swift; sourceTree = "<group>"; };
 		1808C31A22488D8300FD7F45 /* TransactionBody.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionBody.pb.swift; sourceTree = "<group>"; };
@@ -1150,6 +1152,7 @@
 			isa = PBXGroup;
 			children = (
 				35B8ABDD1F9E5642003E4F57 /* HGCAppUITests.swift */,
+				0B0ADD4123A5735D0069AD41 /* OnboardExistingTests.swift */,
 				35B8ABDF1F9E5642003E4F57 /* Info.plist */,
 			);
 			name = HGCAppUITests;
@@ -1894,6 +1897,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0B0ADD4223A5735D0069AD41 /* OnboardExistingTests.swift in Sources */,
 				35B8ABDE1F9E5642003E4F57 /* HGCAppUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/HGCApp/AppDelegate.swift
+++ b/HGCApp/AppDelegate.swift
@@ -90,6 +90,7 @@ extension AppDelegate {
         splashWindow?.rootViewController = UIStoryboard.init(name: "LaunchScreen", bundle: Bundle.main).instantiateInitialViewController()
         splashWindow?.windowLevel = UIWindow.Level.init(rawValue: 3)
         window = UIWindow.init(frame: UIScreen.main.bounds)
+        window!.accessibilityIdentifier = "Main Window"
         AppDelegate.authManager = AuthManager.init(mainWindow: window!)
         
         NotificationCenter.default.addObserver(self, selector:#selector(AppDelegate.onOnboardDidSuccess), name:WalletHelper.onboardDidSuccess, object: nil)

--- a/HGCApp/UI/Accounts/AccountDetailView.xib
+++ b/HGCApp/UI/Accounts/AccountDetailView.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,14 +15,14 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uYa-LY-kuW" userLabel="margin">
-                    <rect key="frame" x="20" y="20" width="335" height="1"/>
+                    <rect key="frame" x="20" y="0.0" width="335" height="1"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="M0r-rm-XCi"/>
                     </constraints>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="P0r-ih-LhW">
-                    <rect key="frame" x="0.0" y="20" width="375" height="329"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="329"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SXd-t0-unX" userLabel="NickName">
                             <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
@@ -43,7 +41,6 @@
                                     <constraints>
                                         <constraint firstAttribute="height" constant="36" placeholder="YES" id="Ih4-nG-mUr"/>
                                     </constraints>
-                                    <nil key="textColor"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <textInputTraits key="textInputTraits" returnKeyType="done"/>
                                     <connections>
@@ -88,10 +85,10 @@
                                 </label>
                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LYV-iT-6gr" customClass="HGCTextField" customModule="HGCApp" customModuleProvider="target">
                                     <rect key="frame" x="20" y="27" width="335" height="36"/>
+                                    <accessibility key="accessibilityConfiguration" identifier="Account ID"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="36" placeholder="YES" id="68X-3P-u34"/>
                                     </constraints>
-                                    <nil key="textColor"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                     <textInputTraits key="textInputTraits" returnKeyType="done"/>
                                     <connections>
@@ -134,6 +131,7 @@
                                 </button>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Labeld dsdafdf Labeld dsdafdf Labeld dsdafdf Labeld dsdafdf Labeld dsdafdf Labeld dsdafdf Labeld dsdafdf " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" minimumScaleFactor="0.25" translatesAutoresizingMaskIntoConstraints="NO" id="MMe-s4-8vR" customClass="HGCLabel" customModule="HGCApp" customModuleProvider="target">
                                     <rect key="frame" x="20" y="27" width="335" height="61"/>
+                                    <accessibility key="accessibilityConfiguration" identifier="Public Key"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>

--- a/HGCApp/UI/Common/Views/HGCKeyboardToolBar.swift
+++ b/HGCApp/UI/Common/Views/HGCKeyboardToolBar.swift
@@ -31,6 +31,7 @@ class HGCKeyboardToolBar: UIToolbar {
     private func setup() {
         let flexi = UIBarButtonItem.init(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
         let doneButton = UIBarButtonItem.init(title: "Dismiss", style: .plain, target: self, action: #selector(self.onDoneTap))
+        doneButton.accessibilityIdentifier = "Dismiss Keyboard"
         self.items = [flexi,doneButton]
     }
     

--- a/HGCApp/UI/ContainerViewController.swift
+++ b/HGCApp/UI/ContainerViewController.swift
@@ -64,12 +64,14 @@ class ContainerViewController: UIViewController {
         homeButton.addTarget(self, action:  #selector(onHomeBuutonTap), for: .touchUpInside)
         
         let refreshButton = UIButton.init(frame: CGRect.init(x: 0, y: 0, width: 44, height: 44))
+        refreshButton.accessibilityIdentifier = "Refresh"
         refreshButton.setImage(UIImage.init(named: "icon-sync"), for: .normal)
         refreshButton.contentEdgeInsets.right = -30
         refreshButton.addTarget(self, action:  #selector(onRefreshButtonTap), for: .touchUpInside)
         
         self.navigationItem.leftBarButtonItem = UIBarButtonItem.init(customView: homeButton)
         self.navigationItem.rightBarButtonItems = [UIBarButtonItem.init(image: UIImage.init(named: "icon-menu"), style: .plain, target: self, action: #selector(onMenuButtonTap)), UIBarButtonItem.init(customView: refreshButton)]
+        self.navigationItem.rightBarButtonItems?[0].accessibilityIdentifier = "Side Menu Button"
         
         self.embededNavCtrl.navigationBar.barTintColor = Color.titleBarBackgroundColor()
         self.embededNavCtrl.navigationBar.tintColor = Color.primaryTextColor()

--- a/HGCApp/UI/SideMenu/LeftMenuViewController.swift
+++ b/HGCApp/UI/SideMenu/LeftMenuViewController.swift
@@ -310,6 +310,7 @@ class LeftMenuViewController: UIViewController, UITableViewDelegate, UITableView
         let cell = tableView.dequeueReusableCell(withIdentifier: "leftMenuCell", for: indexPath) as! LeftMenuCell;
         let menu = self.sections[indexPath.section].items[indexPath.row]
         cell.menuTitle.text = menu.title;
+        cell.accessibilityIdentifier = menu.title + " Cell"
         cell.menuImageView.image = nil
         return cell;
     }

--- a/HGCApp/UI/Storyboards/Base.lproj/Main.storyboard
+++ b/HGCApp/UI/Storyboards/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -49,6 +49,7 @@
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="F36-1n-IHc">
                                                 <rect key="frame" x="157.5" y="-5" width="60" height="30"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="Account Details Drawer Button"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="a24-wD-lzO"/>
                                                     <constraint firstAttribute="width" constant="60" id="esc-4q-Hbj"/>
@@ -209,6 +210,7 @@
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <accessibility key="accessibilityConfiguration" identifier="Overview View Root"/>
                         <constraints>
                             <constraint firstItem="Bc7-rD-GGi" firstAttribute="leading" secondItem="wTd-7A-eOp" secondAttribute="leading" id="15L-Er-5uI"/>
                             <constraint firstItem="Bc7-rD-GGi" firstAttribute="top" secondItem="wTd-7A-eOp" secondAttribute="top" id="a92-2S-z9k"/>
@@ -1126,6 +1128,7 @@
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="985.301" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="pwY-BL-4pD">
                                                         <rect key="frame" x="0.0" y="0.0" width="156.5" height="50.5"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="Account Balance"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="42"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -1327,6 +1330,7 @@
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <accessibility key="accessibilityConfiguration" identifier="Account Details View Root"/>
                         <constraints>
                             <constraint firstItem="izc-P5-gl4" firstAttribute="top" secondItem="8QG-yI-BAW" secondAttribute="top" id="8LK-5M-bar"/>
                             <constraint firstItem="8QG-yI-BAW" firstAttribute="bottom" secondItem="izc-P5-gl4" secondAttribute="bottom" id="XiP-HZ-1vs"/>

--- a/HGCApp/UI/Storyboards/Welcome.storyboard
+++ b/HGCApp/UI/Storyboards/Welcome.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -123,6 +123,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8eM-uM-tXC" customClass="HGCButton" customModule="HGCApp" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="64" width="280" height="44"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="Security PIN"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="dRj-HT-PHV"/>
                                         </constraints>
@@ -141,6 +142,7 @@
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <accessibility key="accessibilityConfiguration" identifier="Security Setup Options View Root"/>
                         <constraints>
                             <constraint firstItem="NI7-aX-rzo" firstAttribute="centerX" secondItem="dlg-EL-zLN" secondAttribute="centerX" id="83X-6I-Ufh"/>
                             <constraint firstItem="NI7-aX-rzo" firstAttribute="centerY" secondItem="dlg-EL-zLN" secondAttribute="centerY" id="BZO-h9-HqF"/>
@@ -426,6 +428,7 @@
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nwo-lg-EUS" customClass="HGCButton" customModule="HGCApp" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="120" height="30"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="Backup Phrase Done"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="120" id="aYm-Uu-5gY"/>
                                                 </constraints>
@@ -463,6 +466,7 @@
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="QHE-le-W5X">
                                 <rect key="frame" x="30" y="144.66666666666666" width="354" height="129.99999999999997"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <accessibility key="accessibilityConfiguration" identifier="Backup Phrase Text View"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
@@ -477,6 +481,7 @@
                             </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <accessibility key="accessibilityConfiguration" identifier="Backup Wallet View Root"/>
                         <constraints>
                             <constraint firstItem="76i-xc-OII" firstAttribute="top" secondItem="mjZ-LG-daZ" secondAttribute="top" constant="30" id="4fj-ss-0Vb"/>
                             <constraint firstItem="QHE-le-W5X" firstAttribute="trailing" secondItem="ODh-rP-JqO" secondAttribute="trailing" id="6uo-Xb-8Oa"/>
@@ -546,6 +551,7 @@
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XNO-4x-9Wd" customClass="HGCButton" customModule="HGCApp" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="104.33333333333331" width="280" height="44"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="Onboard Existing Account"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="aZI-I6-zBd"/>
                                         </constraints>
@@ -564,6 +570,7 @@
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <accessibility key="accessibilityConfiguration" identifier="Wallet Setup Options View Root"/>
                         <constraints>
                             <constraint firstItem="jog-cm-KWh" firstAttribute="top" secondItem="Rfv-XX-OyT" secondAttribute="bottom" constant="40" id="AwZ-18-kgd"/>
                             <constraint firstItem="jog-cm-KWh" firstAttribute="centerX" secondItem="Oye-Tb-uC8" secondAttribute="centerX" id="Ytf-1h-9qc"/>
@@ -662,16 +669,17 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="If you don't know the account number, you can get it from the hedera portal " textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zc1-8P-Log" customClass="ActiveLabel" customModule="ActiveLabel">
-                                <rect key="frame" x="20" y="74" width="374" height="40.666666666666657"/>
+                                <rect key="frame" x="20" y="74" width="374" height="41"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wSe-w5-ZXY" customClass="HGCBoxView" customModule="HGCApp" customModuleProvider="target">
-                                <rect key="frame" x="20" y="154.66666666666666" width="374" height="44"/>
+                                <rect key="frame" x="20" y="155" width="374" height="44"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="dhR-d9-Yk4" customClass="HGCTextField" customModule="HGCApp" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="374" height="44"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="Restore Account ID Text Field"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                                     </textField>
@@ -686,13 +694,14 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RTo-8b-hcJ">
-                                <rect key="frame" x="0.0" y="238.66666666666663" width="414" height="70"/>
+                                <rect key="frame" x="0.0" y="239" width="414" height="70"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ofX-NG-Rkx">
-                                        <rect key="frame" x="147" y="20.000000000000028" width="120" height="30"/>
+                                        <rect key="frame" x="147" y="20" width="120" height="30"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EEw-8Q-FVi" customClass="HGCButton" customModule="HGCApp" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="120" height="30"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="Restore Account ID Done"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="120" id="J1g-tm-Vy3"/>
                                                 </constraints>
@@ -729,6 +738,7 @@
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <accessibility key="accessibilityConfiguration" identifier="Restore Account ID View Root"/>
                         <constraints>
                             <constraint firstItem="RTo-8b-hcJ" firstAttribute="top" secondItem="wSe-w5-ZXY" secondAttribute="bottom" constant="40" id="4Oq-Br-nFb"/>
                             <constraint firstItem="RTo-8b-hcJ" firstAttribute="leading" secondItem="p2h-Go-CPv" secondAttribute="leading" id="8k6-WY-4Ft"/>

--- a/tests/HGCAppUITests/OnboardExistingTests.swift
+++ b/tests/HGCAppUITests/OnboardExistingTests.swift
@@ -1,0 +1,318 @@
+//
+//  Copyright 2019 Hedera Hashgraph LLC
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+
+/**
+ Tests for the Onboard Existing path.
+
+ For these tests, a account has been fully created prior to the test.  The test pathway starts from a fresh install, continues through the user supplying information for the
+ fully created account, and at the latest ends when all account information has been loaded and the account overview page is reached.  (Note that additional screens
+ may be viewed after this to confirm the resulting state.)
+ */
+class OnboardExistingTests: XCTestCase {
+
+    /// The recovery phrase expected to be linked to the primary account.
+    private var expectedRecoveryPhrase: String? = Optional.none
+
+    /// The account ID expected to be in the wallet.
+    private var expectedAccountID: String? = Optional.none
+
+    /// The public key for the above account ID.
+    private var expectedPublicKey: String? = Optional.none
+
+    /// The balance of the account with the above ID.
+    private var expectedAccountBalance: UInt64? = Optional.none
+
+    /**
+     Framework-internal setup to start from a fresh install state.
+
+     - Note: See inside the function for comments describing actions that need to be performed outside of this script for correct test execution.
+     */
+    override func setUp() {
+        super.setUp()
+
+        // External step: Clear app data
+        //
+        // The application execution should proceed as if execution were occurring after a fresh install.  There are
+        // two methods to do this.
+        //
+        //      1. Uninstall the app
+        //      -- OR --
+        //      2. Remove app data
+        //          2a. Request that the app remove its data locally.
+        //              This is done by running the application and selecting the 'Master Reset' option.
+        //          2b. Delete the app data directory for the simulator.
+        //              The directory follows the below pattern:
+        //                  /Users/<user_name>/Library/Developer/CoreSimulator/Devices/<device_uuid>/ \
+        //                      data/Containers/Data/Application/<app_uuid>
+        //              This step should be taken while the simulator is SHUT DOWN.  It'll be quite upset if the
+        //              directory disappears during execution.
+
+        // External environment variable: EXISTING_ACCOUNT_RECOVERY_PHRASE
+        //
+        // The application will load an account ID linked to a ED25519 seed derived via BIP32 from a mnemonic via
+        // BIP39.  We refer to the mnemonic as a "recovery phrase".
+        expectedRecoveryPhrase = ProcessInfo.processInfo.environment["EXISTING_ACCOUNT_RECOVERY_PHRASE"]
+
+        // External environment variable: EXISTING_ACCOUNT_ID
+        //
+        // The application will load an account ID.
+        expectedAccountID = ProcessInfo.processInfo.environment["EXISTING_ACCOUNT_ID"]
+
+        // External environment variable: EXISTING_ACCOUNT_PUBLIC_KEY
+        //
+        // The application will load an account ID whose signatures can be verified with this public key.
+        expectedPublicKey = ProcessInfo.processInfo.environment["EXISTING_ACCOUNT_PUBLIC_KEY"]
+
+        // External environment variable: EXISTING_ACCOUNT_BALANCE
+        //
+        // The application will retrieve the balance of the account matching a loaded account ID.
+        do {
+            let expectedAccountBalanceText = ProcessInfo.processInfo.environment["EXISTING_ACCOUNT_BALANCE"]
+            expectedAccountBalance = expectedAccountBalanceText.flatMap(UInt64.init)
+        }
+
+        continueAfterFailure = false
+        XCUIApplication().launch()
+    }
+
+    /// Convert a decimal HBAR value into tinybars.
+    private func tinybars(from hbarDecimalText: String) -> UInt64 {
+        let parts = hbarDecimalText.split(separator: ".")
+        XCTAssertGreaterThan(parts.count, 0)
+        let wholePart = UInt64(parts[0])
+        let tinyPart: UInt64
+        if parts.count > 1 {
+            let length = parts[1].count
+            let textValue = UInt64(parts[1])
+            XCTAssertNotNil(textValue)
+            XCTAssertLessThanOrEqual(length, 8)
+            var adjustedValue = textValue!
+            for _ in 0..<(8 - length) {
+                adjustedValue = adjustedValue * 10
+            }
+            tinyPart = adjustedValue
+        }
+        else {
+            tinyPart = 0
+        }
+        XCTAssertNotNil(wholePart)
+        return wholePart! * 100_000_000 + tinyPart
+    }
+
+    /**
+     Get the main window for the app.
+
+     Exclude view searches to the main window to ensure that the views are actually part of the target view hierarchy.
+
+     - Precondition: The app is expected to always have a main window when running.  That window must have the identifier, "MainWindow".
+     */
+    private func getMainWindow() -> XCUIElement {
+        let window = XCUIApplication().windows["Main Window"]
+        XCTAssert(window.exists)
+        return window
+    }
+
+    /**
+     Get the root view of an active view controller's view hierarchy from within the active window.
+
+     Exclude view searches to a specific view controller to shrink teh search space and avoid potential naming conflicts.
+     */
+    private func getRootView(in window: XCUIElement, forVCNamed vcName: String) -> XCUIElement {
+        // Note: Root views aren't in any particular category because they are UIView and not a subclass.
+        let matches = window.descendants(matching: .other).matching(identifier: vcName + " View Root")
+        // Note: this may also occur during development before all view controller root views are labeled.
+        XCTAssertEqual(matches.count, 1, "Test failure: not in \(vcName) View Controller.")
+        return matches.firstMatch
+    }
+
+    /// Get a view within another view.
+    private func getView(within view: XCUIElement,
+                         named name: String = "",
+                         ofType type: XCUIElement.ElementType = .any) -> XCUIElement {
+        var matches = view.descendants(matching: type)
+        matches = name != "" ? matches.matching(identifier: name) : matches
+        XCTAssertEqual(matches.count, 1, "Test failure: view " + (name != "" ? "\"\(name)\" " : "") + "not found.")
+        return matches.firstMatch
+    }
+
+    /// Dismiss the keyboard if one is present.
+    private func dismissKeyboard() {
+        let button = XCUIApplication().toolbars.buttons["Dismiss Keyboard"]
+        if (button.exists) {
+            button.tap()
+        }
+    }
+
+    /// Test the ideal user path through the Onboard Existing process.
+    func testIdealUserPath() {
+
+        // Steps on Wallet Setup Options screen.
+        do {
+            // Validation: first screen must be Wallet Setup Options.
+            let window = getMainWindow()
+            let rootView = getRootView(in: window, forVCNamed: "Wallet Setup Options")
+
+            // User action: tap the button representing the onboard existing path.
+            let nextStepButton = getView(within: rootView, named: "Onboard Existing Account", ofType: .button)
+            nextStepButton.tap()
+        }
+
+        // Steps on Backup Wallet screen.
+        do {
+            // Validation: screen must be Backup Wallet.
+            let window = getMainWindow()
+            let rootView = getRootView(in: window, forVCNamed: "Backup Wallet")
+
+            // User action: enter recovery phrase.
+            let recoveryPhraseEntryField = getView(within: rootView, named: "Backup Phrase Text View",
+                                                   ofType: .textView)
+            recoveryPhraseEntryField.tap()
+            XCTAssertNotNil(expectedRecoveryPhrase)
+            recoveryPhraseEntryField.typeText(expectedRecoveryPhrase!)
+            dismissKeyboard()
+
+            // User action: tap the button representing the continuation path.
+            let nextButton = getView(within: rootView, named: "Backup Phrase Done")
+            nextButton.tap()
+        }
+
+        // Steps on Restore Account ID screen.
+        do {
+            // Validation: screen must be Restore Account ID.
+            let window = getMainWindow()
+            let rootView = getRootView(in: window, forVCNamed: "Restore Account ID")
+
+            // User action: enter account ID.
+            let accountIDEntryField = getView(within: rootView, named: "Restore Account ID Text Field",
+                                              ofType: .textField)
+            accountIDEntryField.tap()
+            XCTAssertNotNil(expectedAccountID, "Environment failure")
+            accountIDEntryField.typeText(expectedAccountID!)
+            dismissKeyboard()
+
+            // User action: tap the button representing the continuation path.
+            let nextButton = getView(within: rootView, named: "Restore Account ID Done")
+            nextButton.tap()
+        }
+
+        // Steps on Wallet Restored Successfully alert.
+        do {
+            // Validation: confirm there is an alert
+            let alerts = XCUIApplication().alerts
+            XCTAssertEqual(alerts.count, 1)
+            let alert = alerts.firstMatch
+
+            // Validation: confirm this is the successful alert
+            XCTAssertEqual(alert.label, "Wallet restored successfully")
+
+            // User action: dismiss the alert.
+            let buttons = alert.buttons
+            XCTAssertEqual(buttons.count, 1)
+            let button = buttons.firstMatch
+            button.tap()
+        }
+
+        // Steps on Security Setup Options screen.
+        do {
+            // Validation: screen must be Security Setup Options.
+            let window = getMainWindow()
+            let rootView = getRootView(in: window, forVCNamed: "Security Setup Options")
+
+            // User action: tap the button representing the PIN entry path.
+            let nextButton = getView(within: rootView, named: "Security PIN")
+            nextButton.tap()
+        }
+
+        // Steps on PIN Entry screen (enter new PIN, then confirm new PIN).
+        for _ in 0 ..< 2 {
+            let pinOne = XCUIApplication().descendants(matching: .any).matching(NSPredicate(format: "label == '1'"))
+            XCTAssertEqual(pinOne.count, 1)
+            for _ in 0 ..< 4 {
+                pinOne.firstMatch.tap()
+            }
+            let done = XCUIApplication().descendants(matching: .any).matching(NSPredicate(format: "label == 'OK'"))
+            done.firstMatch.tap()
+        }
+
+        // Steps on Overview screen.
+        do {
+            // Validation: screen must be Overview.
+            let window = getMainWindow()
+            let rootView = getRootView(in: window, forVCNamed: "Overview")
+
+            // User action: refresh account information.
+            do {
+                let spinnerQuery = XCUIApplication().descendants(matching: .progressIndicator)
+                let spinnerExists = NSPredicate(format: "exists = true")
+                let spinnerMissing = NSPredicate(format: "exists = false")
+                let expectSpinnerExists = expectation(for: spinnerExists, evaluatedWith: spinnerQuery, handler: nil)
+                let refreshButton = getView(within: window, named: "Refresh")
+                refreshButton.tap()
+                let resultAppeared = XCTWaiter().wait(for: [expectSpinnerExists], timeout: 1)
+                if resultAppeared == .completed {
+                    let expectSpinnerMissing = expectation(for: spinnerMissing, evaluatedWith: spinnerQuery, handler: nil)
+                    let resultDisappeared = XCTWaiter().wait(for: [expectSpinnerMissing], timeout: 7)
+                    XCTAssertEqual(resultDisappeared, .completed)
+                }
+            }
+
+            // User action: read account balance.
+            let balanceView = getView(within: rootView, named: "Account Balance")
+            let balanceText = balanceView.label
+            print("Account balance (text): " + balanceText)
+            let _: UInt64 = tinybars(from: balanceText)
+
+            // Validation: check account balance matches.
+            // FIXME: This is hard for the environment to calculate because the amount shown will be AFTER the
+            // transaction that links the account.  Each linkage costs HBAR, but the amount can change over time.
+            //XCTAssertNotNil(expectedAccountBalance, "Environment failure")
+            //XCTAssertEqual(actualBalance, expectedAccountBalance!)
+
+            // User action: open side menu.
+            let sideMenuButton = getView(within: window, named: "Side Menu Button", ofType: .button)
+            sideMenuButton.tap()
+
+            // User action: open account details.
+            let accountDetailsCell = getView(within: window, named: "Default Account Cell", ofType: .cell)
+            accountDetailsCell.tap()
+        }
+
+        // Steps in Account Details screen.
+        do {
+            // Validation: screen must be Account Details.
+            let window = getMainWindow()
+            let rootView = getRootView(in: window, forVCNamed: "Account Details")
+
+            // User action: read account ID.
+            let accountIDView = getView(within: rootView, named: "Account ID", ofType: .textField)
+            let actualAccountID = accountIDView.value as? String ?? ""
+
+            // Validation: check account ID matches.
+            XCTAssertNotNil(expectedAccountID, "Environment failure")
+            XCTAssertEqual(actualAccountID, expectedAccountID)
+
+            // User action: read account public key.
+            let accountPublicKeyView = getView(within: rootView, named: "Public Key", ofType: .staticText)
+            let actualPublicKey = accountPublicKeyView.label
+
+            // Validation: check public key matches.
+            XCTAssertNotNil(expectedPublicKey, "Environment failure")
+            XCTAssertEqual(actualPublicKey, expectedPublicKey)
+        }
+    }
+}


### PR DESCRIPTION
Implement a basic test to go through the case of onboarding an existing
account with ideal user behavior.

This test requires environmental configuration information to be
provided.  At this time, no mechanism exists to do so in an automated
fashion.

This test is designed to confirm the balance of the account, however it
is clear that loading the account actually has an HBAR cost.  This
change therefore does not test for the balance by value to avoid
additional complexity involved with the exchange rate.

Changes:
- Test helper implementations
- Test implementation
- Addition of accessibility identifiers for XCUITest manipulation

Testing:
- Passes locally with external-to-test modifications.  Visual inspection
  of the test execution on the simulator was performed.
  (Specifically, a specific account's information specified in the
  appropriate environment variables via the test scheme.)

Ad-hoc testing:
- getMainWindow
    - Bogus window name asserted.
    - Test calling getMainWindow did not assert.
- getRootView
    - Bogus root view name asserted.
    - Test calling getRootView did not assert.
- getView
    - Bogus inner view name failed with an assertion.
    - Providing no name or type failed as appropriate, with an assertion
      that more than one view was found.
    - Providing just the type failed as appropriate, with an assertion
      that more than one button view was found.
    - Providing just the correct name passed.
    - Providing the correct name but the wrong type failed with an
      assertion.
    - Providing both the correct name and correct type passed.
- dismissKeyboard
    - Does not fail if there is no keyboard to dismiss.
    - Confirmed visually that when a keyboard is up, it is dismissed.

Missing Testing:
- A whole HBAR value for account balance