### PR TITLE
Issue #213: Use public testnet

### DIFF
--- a/HGCApp/Supporting Files/nodes-testnet.json
+++ b/HGCApp/Supporting Files/nodes-testnet.json
@@ -1,92 +1,29 @@
 [
     {
-        "host": "35.196.146.2",
+        "host": "0.testnet.hedera.com",
         "port": 50211,
         "accountNum": 3,
         "shardNum": 0,
         "realmNum": 0
     },
     {
-        "host": "35.245.91.14",
+        "host": "1.testnet.hedera.com",
         "port": 50211,
         "accountNum": 4,
         "shardNum": 0,
         "realmNum": 0
     },
     {
-        "host": "34.67.95.76",
+        "host": "2.testnet.hedera.com",
         "port": 50211,
         "accountNum": 5,
         "shardNum": 0,
         "realmNum": 0
     },
     {
-        "host": "35.203.145.150",
+        "host": "3.testnet.hedera.com",
         "port": 50211,
         "accountNum": 6,
-        "shardNum": 0,
-        "realmNum": 0
-    },
-    {
-        "host": "34.94.112.161",
-        "port": 50211,
-        "accountNum": 7,
-        "shardNum": 0,
-        "realmNum": 0
-    },
-    {
-        "host": "34.95.37.183",
-        "port": 50211,
-        "accountNum": 8,
-        "shardNum": 0,
-        "realmNum": 0
-    },
-    {
-        "host": "34.76.213.6",
-        "port": 50211,
-        "accountNum": 9,
-        "shardNum": 0,
-        "realmNum": 0
-    },
-    {
-        "host": "34.89.53.144",
-        "port": 50211,
-        "accountNum": 10,
-        "shardNum": 0,
-        "realmNum": 0
-    },
-    {
-        "host": "35.198.144.75",
-        "port": 50211,
-        "accountNum": 11,
-        "shardNum": 0,
-        "realmNum": 0
-    },
-    {
-        "host": "34.90.15.85",
-        "port": 50211,
-        "accountNum": 12,
-        "shardNum": 0,
-        "realmNum": 0
-    },
-    {
-        "host": "34.92.29.237",
-        "port": 50211,
-        "accountNum": 13,
-        "shardNum": 0,
-        "realmNum": 0
-    },
-    {
-        "host": "35.194.216.81",
-        "port": 50211,
-        "accountNum": 14,
-        "shardNum": 0,
-        "realmNum": 0
-    },
-    {
-        "host": "34.84.108.224",
-        "port": 50211,
-        "accountNum": 15,
         "shardNum": 0,
         "realmNum": 0
     }


### PR DESCRIPTION
Redirect our "testnet" node list to point to the testnet DNS names
rather than IP addresses.

Testing:
Basic onboard existing test passed.
Verified list of nodes and ports from inside the app.

Risks:

It is possible that some elements of the system depend on the JSON
elements being IPv4 addresses instead of DNS resolution names.
Recommend verification that testnet node updates are stored properly in
our data model before public release.