### PR TITLE
Issue #220: Use median exchange rate

### DIFF
--- a/HGCApp/Services/APIServices/AppConfigService.swift
+++ b/HGCApp/Services/APIServices/AppConfigService.swift
@@ -109,14 +109,14 @@ class AppConfigService {
                    task.resume()
                }
     }
-    
+
+    /// Load our exchange rate property with the median of all exchange rates that were reported to us.
     private func loadExchangeRate() {
-        let rates:[Double] = getAllRates().compactMap { (info) -> Double? in
-            return info.last
-        }
-        if !rates.isEmpty {
-            exchangeRate =  rates.reduce(0, +)/Double(rates.count)
-        }
+        let rates: [Double] = getAllRates().compactMap{ $0.last }.sorted()
+        guard !rates.isEmpty else { return }
+        let lowerMedianIndex = rates.count / 2
+        let offset = rates.count % 2 == 0 ? 1 : 0
+        exchangeRate = (rates[lowerMedianIndex] + rates[lowerMedianIndex - offset]) / 2
     }
     
     func getAllRates() -> [ExchangeRateInfo] {


### PR DESCRIPTION
The app prior to this change displayed the exchange rate as the mean of
the queried exchanges' rates.  After this change, the median is used
instead.

Tested manually with even and odd numbers of exchanges.  With even
numbers, the average of the two elements closest to the middle are taken
as is traditional.