### PR TITLE
added command argument to build xctestrun file when building for test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,18 +102,18 @@ workflows:
   build-and-test:
     jobs:
       - ios-environment-setup
-      - build-for-testing:
-         requires:
-           - ios-environment-setup
-      - run-unit-tests:
-         requires:
-           - build-for-testing
-      - build-for-ui-testing:
-         requires:
-           - run-unit-tests
-      - run-ui-tests:
-         requires:
-           - build-for-ui-testing
-      - build-for-running:
-         requires:
-           - run-ui-tests
+      # - build-for-testing:
+      #    requires:
+      #      - ios-environment-setup
+      # - run-unit-tests:
+      #    requires:
+      #      - build-for-testing
+      # - build-for-ui-testing:
+      #    requires:
+      #      - run-unit-tests
+      # - run-ui-tests:
+      #    requires:
+      #      - build-for-ui-testing
+      # - build-for-running:
+      #    requires:
+      #      - run-ui-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,9 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 8'
             -derivedDataPath build
       - run:
+          name: List Contents
+          command: ls -lrt build/Build/Products/
+      - run:
           name: Run OnboardExistingTests
           command: xcodebuild test-without-building
             -xctestrun build/Build/Products/Debug_iphonesimulator13.4-x86_64.xctestrun 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ jobs:
       - run:
           name: Install Dependencies
           command: .circleci/scripts/install_dependencies.sh
+      - persist_to_workspace:
+          root: /Users/distiller/project/
   build-for-testing:
     macos:
       xcode: "11.3.1"
@@ -46,6 +48,8 @@ jobs:
              -scheme Debug
              -configuration Debug
              -destination 'platform=iOS Simulator,name=iPhone 8'
+       - persist_to_workspace:
+           root: /Users/distiller/project/
   run-unit-tests:
     macos:
       xcode: "11.3.1"
@@ -59,6 +63,8 @@ jobs:
              -scheme Debug
              -configuration Debug
              -destination 'platform=iOS Simulator,name=iPhone 8'
+       - persist_to_workspace:
+           root: /Users/distiller/project/
   build-for-ui-testing:
     macos:
       xcode: "11.3.1"
@@ -72,6 +78,8 @@ jobs:
             -scheme Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
             -derivedDataPath build
+      - persist_to_workspace:
+          root: /Users/distiller/project/
   run-ui-tests:
     macos:
       xcode: "11.3.1"
@@ -84,6 +92,8 @@ jobs:
             -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
             -destination 'platform=iOS Simulator,name=iPhone 8'
             -only-testing:HGCAppUITests/OnboardExistingTests.swift
+      - persist_to_workspace:
+          root: /Users/distiller/project/
   build-for-running:
     macos:
       xcode: "11.3.1"
@@ -97,6 +107,8 @@ jobs:
             -scheme Debug
             -configuration Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
+      - persist_to_workspace:
+          root: /Users/distiller/project/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
             -scheme Debug
             -configuration Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
-            -skip-testing HGCAppUITests/OnboardExistingTests.swift
+            -skip-testing HGCAppUITests/OnboardExistingTests/testIdealUserPath
       - persist_to_workspace:
           root: /
           paths:
@@ -112,7 +112,7 @@ jobs:
           command: xcodebuild test-without-building
             -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
             -destination 'platform=iOS Simulator,name=iPhone 8'
-            -only-testing HGCAppUITests/OnboardExistingTests.swift
+            -only-testing:HGCAppUITests/OnboardExistingTests.swift
       - persist_to_workspace:
           root: /
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,20 +33,20 @@ jobs:
       - run:
           name: Install Dependencies
           command: .circleci/scripts/install_dependencies.sh
-      - run:
-          name: Build for testing
-          command: xcodebuild build-for-testing
-            -workspace HGCApp.xcworkspace
-            -scheme Debug
-            -configuration Debug
-            -destination 'platform=iOS Simulator,name=iPhone 8'
-      - run:
-          name: Run unit tests
-          command: xcodebuild test-without-building
-            -workspace HGCApp.xcworkspace
-            -scheme Debug
-            -configuration Debug
-            -destination 'platform=iOS Simulator,name=iPhone 8'
+#      - run:
+#          name: Build for testing
+#          command: xcodebuild build-for-testing
+#            -workspace HGCApp.xcworkspace
+#            -scheme Debug
+#            -configuration Debug
+#            -destination 'platform=iOS Simulator,name=iPhone 8'
+#      - run:
+#          name: Run unit tests
+#          command: xcodebuild test-without-building
+#            -workspace HGCApp.xcworkspace
+#            -scheme Debug
+#            -configuration Debug
+#            -destination 'platform=iOS Simulator,name=iPhone 8'
       - run:
           name: Build for UI testing
           command: xcodebuild build-for-testing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,10 @@ jobs:
           name: Install Dependencies
           command: .circleci/scripts/install_dependencies.sh
   build-for-testing:
+    macos:
+      xcode: "11.3.1"
+    environment:
+      FL_OUTPUT_DIR: output
     requires:
       - ios-environment-setup
     steps:
@@ -45,6 +49,10 @@ jobs:
              -configuration Debug
              -destination 'platform=iOS Simulator,name=iPhone 8'
   run-unit-tests:
+    macos:
+      xcode: "11.3.1"
+    environment:
+      FL_OUTPUT_DIR: output
     pre-steps:
       - build-for-testing
     steps:
@@ -56,6 +64,10 @@ jobs:
              -configuration Debug
              -destination 'platform=iOS Simulator,name=iPhone 8'
   build-for-ui-testing:
+    macos:
+      xcode: "11.3.1"
+    environment:
+      FL_OUTPUT_DIR: output
     requires:
       - ios-environment-setup
     steps:
@@ -67,6 +79,10 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 8'
             -derivedDataPath build
   run-ui-tests:
+    macos:
+      xcode: "11.3.1"
+    environment:
+      FL_OUTPUT_DIR: output
     pre-steps:
       - build-for-ui-testing
     steps:
@@ -77,6 +93,10 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 8'
             -only-testing:HGCAppUITests/OnboardExistingTests.swift
   build-for-running:
+    macos:
+      xcode: "11.3.1"
+    environment:
+      FL_OUTPUT_DIR: output
     requires:
       - ios-environment-setup
     steps:
@@ -90,7 +110,7 @@ jobs:
 
 workflows:
   version: 2
-  build-and-unit-test:
+  build-and-test:
     jobs:
       - run-unit-tests
       - run-ui-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,11 +110,9 @@ workflows:
           - build-for-testing
       - run-ui-tests:
         requires:
-          - ios-environment-setup
           - run-unit-tests
         pre-steps:
           - build-for-ui-testing
       - build-for-running:
         requires:
-          - ios-environment-setup
           - run-ui-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,26 +79,26 @@ jobs:
           paths:
             - Users/distiller/project
             - Users/distiller/Library
-  build-for-ui-testing:
-    macos:
-      xcode: "11.3.1"
-    environment:
-      FL_OUTPUT_DIR: output
-    steps:
-      - attach_workspace:
-          at: /
-      - run:
-          name: Build for UI testing
-          command: xcodebuild build-for-testing
-            -workspace HGCApp.xcworkspace
-            -scheme Debug
-            -destination 'platform=iOS Simulator,name=iPhone 8'
-            -derivedDataPath build
-      - persist_to_workspace:
-          root: /
-          paths:
-            - Users/distiller/project
-            - Users/distiller/Library
+  # build-for-ui-testing:
+  #   macos:
+  #     xcode: "11.3.1"
+  #   environment:
+  #     FL_OUTPUT_DIR: output
+  #   steps:
+  #     - attach_workspace:
+  #         at: /
+  #     - run:
+  #         name: Build for UI testing
+  #         command: xcodebuild build-for-testing
+  #           -workspace HGCApp.xcworkspace
+  #           -scheme Debug
+  #           -destination 'platform=iOS Simulator,name=iPhone 8'
+  #           -derivedDataPath build
+  #     - persist_to_workspace:
+  #         root: /
+  #         paths:
+  #           - Users/distiller/project
+  #           - Users/distiller/Library
   run-ui-tests:
     macos:
       xcode: "11.3.1"
@@ -112,7 +112,7 @@ jobs:
           command: xcodebuild test-without-building
             -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
             -destination 'platform=iOS Simulator,name=iPhone 8'
-            -only-testing:HGCAppUITests/OnboardExistingTests.swift
+            -only-testing HGCAppUITests/OnboardExistingTests/testIdealUserPath
       - persist_to_workspace:
           root: /
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,10 +103,11 @@ workflows:
   build-and-test:
     jobs:
       - ios-environment-setup
-      - run-unit-tests:
+      - build-for-testing:
         requires:
           - ios-environment-setup
-        pre-steps:
+      - run-unit-tests:
+        requires:
           - build-for-testing
       # - run-ui-tests:
       #   requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,12 +163,6 @@ workflows:
   build-and-test:
     jobs:
       - ios-environment-setup
-      # - build-for-testing:
-      #    requires:
-      #      - ios-environment-setup
-      # - run-unit-tests:
-      #    requires:
-      #      - build-for-testing
       - build-for-ui-testing:
          requires:
            - ios-environment-setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,10 @@ jobs:
           name: Install Dependencies
           command: .circleci/scripts/install_dependencies.sh
       - persist_to_workspace:
-          root: /
-          paths:
-            - Users/distiller/project
-            - Users/distiller/Library
+            root: /
+            paths:
+              - Users/distiller/project
+              - Users/distiller/Library
   build-for-testing:
     macos:
       xcode: "11.3.1"
@@ -47,17 +47,17 @@ jobs:
       - attach_workspace:
         at: /
       - run:
-        name: Build for testing
-        command: xcodebuild build-for-testing
-          -workspace HGCApp.xcworkspace
-          -scheme Debug
-          -configuration Debug
-          -destination 'platform=iOS Simulator,name=iPhone 8'
+          name: Build for testing
+          command: xcodebuild build-for-testing
+            -workspace HGCApp.xcworkspace
+            -scheme Debug
+            -configuration Debug
+            -destination 'platform=iOS Simulator,name=iPhone 8'
       - persist_to_workspace:
-        root: /
-        paths:
-          - Users/distiller/project
-          - Users/distiller/Library
+          root: /
+          paths:
+            - Users/distiller/project
+            - Users/distiller/Library
   run-unit-tests:
     macos:
       xcode: "11.3.1"
@@ -67,17 +67,17 @@ jobs:
       - attach_workspace:
         at: /
       - run:
-        name: Run unit tests
-        command: xcodebuild test-without-building
-          -workspace HGCApp.xcworkspace
-          -scheme Debug
-          -configuration Debug
-          -destination 'platform=iOS Simulator,name=iPhone 8'
+          name: Run unit tests
+          command: xcodebuild test-without-building
+            -workspace HGCApp.xcworkspace
+            -scheme Debug
+            -configuration Debug
+            -destination 'platform=iOS Simulator,name=iPhone 8'
       - persist_to_workspace:
-        root: /
-        paths:
-          - Users/distiller/project
-          - Users/distiller/Library
+          root: /
+          paths:
+            - Users/distiller/project
+            - Users/distiller/Library
   build-for-ui-testing:
     macos:
       xcode: "11.3.1"
@@ -87,17 +87,17 @@ jobs:
       - attach_workspace:
           at: /
       - run:
-        name: Build for UI testing
-        command: xcodebuild build-for-testing
-          -workspace HGCApp.xcworkspace
-          -scheme Debug
-          -destination 'platform=iOS Simulator,name=iPhone 8'
-          -derivedDataPath build
+          name: Build for UI testing
+          command: xcodebuild build-for-testing
+            -workspace HGCApp.xcworkspace
+            -scheme Debug
+            -destination 'platform=iOS Simulator,name=iPhone 8'
+            -derivedDataPath build
       - persist_to_workspace:
-        root: /
-        paths:
-          - Users/distiller/project
-          - Users/distiller/Library
+          root: /
+          paths:
+            - Users/distiller/project
+            - Users/distiller/Library
   run-ui-tests:
     macos:
       xcode: "11.3.1"
@@ -107,16 +107,16 @@ jobs:
       - attach_workspace:
           at: /
       - run:
-        name: Run OnboardExistingTests
-        command: xcodebuild test-without-building
-          -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
-          -destination 'platform=iOS Simulator,name=iPhone 8'
-          -only-testing:HGCAppUITests/OnboardExistingTests.swift
+          name: Run OnboardExistingTests
+          command: xcodebuild test-without-building
+            -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
+            -destination 'platform=iOS Simulator,name=iPhone 8'
+            -only-testing:HGCAppUITests/OnboardExistingTests.swift
       - persist_to_workspace:
-        root: /
-        paths:
-          - Users/distiller/project
-          - Users/distiller/Library
+          root: /
+          paths:
+            - Users/distiller/project
+            - Users/distiller/Library
   build-for-running:
     macos:
       xcode: "11.3.1"
@@ -133,10 +133,10 @@ jobs:
           -configuration Debug
           -destination 'platform=iOS Simulator,name=iPhone 8'
       - persist_to_workspace:
-        root: /
-        paths:
-          - Users/distiller/project
-          - Users/distiller/Library
+          root: /
+          paths:
+            - Users/distiller/project
+            - Users/distiller/Library
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
             -scheme Debug
             -configuration Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
+            -skip-testing HGCAppUITests/OnboardExistingTests.swift
       - persist_to_workspace:
           root: /
           paths:
@@ -111,7 +112,7 @@ jobs:
           command: xcodebuild test-without-building
             -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
             -destination 'platform=iOS Simulator,name=iPhone 8'
-            -only-testing:HGCAppUITests/OnboardExistingTests.swift
+            -only-testing HGCAppUITests/OnboardExistingTests.swift
       - persist_to_workspace:
           root: /
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 # .circleci/config.yml
-version: 2
+version: 2.1
 jobs:
   ios-environment-setup:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,26 +79,26 @@ jobs:
           paths:
             - Users/distiller/project
             - Users/distiller/Library
-  # build-for-ui-testing:
-  #   macos:
-  #     xcode: "11.3.1"
-  #   environment:
-  #     FL_OUTPUT_DIR: output
-  #   steps:
-  #     - attach_workspace:
-  #         at: /
-  #     - run:
-  #         name: Build for UI testing
-  #         command: xcodebuild build-for-testing
-  #           -workspace HGCApp.xcworkspace
-  #           -scheme Debug
-  #           -destination 'platform=iOS Simulator,name=iPhone 8'
-  #           -derivedDataPath build
-  #     - persist_to_workspace:
-  #         root: /
-  #         paths:
-  #           - Users/distiller/project
-  #           - Users/distiller/Library
+  build-for-ui-testing:
+    macos:
+      xcode: "11.3.1"
+    environment:
+      FL_OUTPUT_DIR: output
+    steps:
+      - attach_workspace:
+          at: /
+      - run:
+          name: Build for UI testing
+          command: xcodebuild build-for-testing
+            -workspace HGCApp.xcworkspace
+            -scheme Debug
+            -destination 'platform=iOS Simulator,name=iPhone 8'
+            -derivedDataPath build
+      - persist_to_workspace:
+          root: /
+          paths:
+            - Users/distiller/project
+            - Users/distiller/Library
   run-ui-tests:
     macos:
       xcode: "11.3.1"
@@ -110,9 +110,7 @@ jobs:
       - run:
           name: Run OnboardExistingTests
           command: xcodebuild test-without-building
-            -scheme Debug
-            -configuration Debug
-            # -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
+            -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
             -destination 'platform=iOS Simulator,name=iPhone 8'
             -only-testing HGCAppUITests/OnboardExistingTests/testIdealUserPath
       - persist_to_workspace:
@@ -135,11 +133,11 @@ jobs:
             -scheme Debug
             -configuration Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
-      # - persist_to_workspace:
-      #     root: /
-      #     paths:
-      #       - Users/distiller/project
-      #       - Users/distiller/Library
+      - persist_to_workspace:
+          root: /
+          paths:
+            - Users/distiller/project
+            - Users/distiller/Library
 
 workflows:
   version: 2
@@ -152,13 +150,12 @@ workflows:
       - run-unit-tests:
          requires:
            - build-for-testing
-      # - build-for-ui-testing:
-      #    requires:
-      #      - run-unit-tests
+      - build-for-ui-testing:
+         requires:
+           - run-unit-tests
       - run-ui-tests:
          requires:
-           # - build-for-ui-testing
-           - run-unit-tests
+           - build-for-ui-testing
       - build-for-running:
          requires:
            - run-ui-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,20 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - run-unit-tests
-      - run-ui-tests
-      - build-for-running
+      - ios-environment-setup
+      - run-unit-tests:
+        requires:
+          - ios-environment-setup
+        pre-steps:
+          - build-for-testing
+      - run-ui-tests:
+        requires:
+          - ios-environment-setup
+        pre-steps:
+          - run-unit-tests
+          - build-for-ui-testing
+      - build-for-running:
+        requires:
+          - ios-environment-setup
+        pre-steps:
+          - run-ui-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,16 +103,16 @@ workflows:
   build-and-test:
     jobs:
       - ios-environment-setup
-      - run-unit-tests:
-        requires:
-          - ios-environment-setup
-        pre-steps:
-          - build-for-testing
-      - run-ui-tests:
-        requires:
-          - run-unit-tests
-        pre-steps:
-          - build-for-ui-testing
-      - build-for-running:
-        requires:
-          - run-ui-tests
+      # - run-unit-tests:
+      #   requires:
+      #     - ios-environment-setup
+      #   pre-steps:
+      #     - build-for-testing
+      # - run-ui-tests:
+      #   requires:
+      #     - run-unit-tests
+      #   pre-steps:
+      #     - build-for-ui-testing
+      # - build-for-running:
+      #   requires:
+      #     - run-ui-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,9 @@ jobs:
           name: Install Dependencies
           command: .circleci/scripts/install_dependencies.sh
       - persist_to_workspace:
-          root: /Users/distiller/project/
+          root: /
+          paths:
+            - Users/distiller/project/
   build-for-testing:
     macos:
       xcode: "11.3.1"
@@ -49,7 +51,9 @@ jobs:
              -configuration Debug
              -destination 'platform=iOS Simulator,name=iPhone 8'
        - persist_to_workspace:
-           root: /Users/distiller/project/
+           root: /
+           paths:
+             - Users/distiller/project/
   run-unit-tests:
     macos:
       xcode: "11.3.1"
@@ -64,7 +68,9 @@ jobs:
              -configuration Debug
              -destination 'platform=iOS Simulator,name=iPhone 8'
        - persist_to_workspace:
-           root: /Users/distiller/project/
+           root: /
+           paths:
+             - Users/distiller/project/
   build-for-ui-testing:
     macos:
       xcode: "11.3.1"
@@ -79,7 +85,9 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 8'
             -derivedDataPath build
       - persist_to_workspace:
-          root: /Users/distiller/project/
+          root: /
+          paths:
+            - Users/distiller/project/
   run-ui-tests:
     macos:
       xcode: "11.3.1"
@@ -93,7 +101,9 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 8'
             -only-testing:HGCAppUITests/OnboardExistingTests.swift
       - persist_to_workspace:
-          root: /Users/distiller/project/
+          root: /
+          paths:
+            - Users/distiller/project/
   build-for-running:
     macos:
       xcode: "11.3.1"
@@ -108,7 +118,9 @@ jobs:
             -configuration Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
       - persist_to_workspace:
-          root: /Users/distiller/project/
+          root: /
+          paths:
+            - Users/distiller/project/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,47 +38,6 @@ jobs:
             paths:
               - Users/distiller/project
               - Users/distiller/Library
-  build-for-testing:
-    macos:
-      xcode: "11.3.1"
-    environment:
-      FL_OUTPUT_DIR: output
-    steps:
-      - attach_workspace:
-          at: /
-      - run:
-          name: Build for testing
-          command: xcodebuild build-for-testing
-            -workspace HGCApp.xcworkspace
-            -scheme Debug
-            -configuration Debug
-            -destination 'platform=iOS Simulator,name=iPhone 8'
-      - persist_to_workspace:
-          root: /
-          paths:
-            - Users/distiller/project
-            - Users/distiller/Library
-  run-unit-tests:
-    macos:
-      xcode: "11.3.1"
-    environment:
-      FL_OUTPUT_DIR: output
-    steps:
-      - attach_workspace:
-          at: /
-      - run:
-          name: Run unit tests
-          command: xcodebuild test-without-building
-            -workspace HGCApp.xcworkspace
-            -scheme Debug
-            -configuration Debug
-            -destination 'platform=iOS Simulator,name=iPhone 8'
-            -skip-testing HGCAppUITests/OnboardExistingTests/testIdealUserPath
-      - persist_to_workspace:
-          root: /
-          paths:
-            - Users/distiller/project
-            - Users/distiller/Library
   build-for-ui-testing:
     macos:
       xcode: "11.3.1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,11 +103,11 @@ workflows:
   build-and-test:
     jobs:
       - ios-environment-setup
-      # - run-unit-tests:
-      #   requires:
-      #     - ios-environment-setup
-      #   pre-steps:
-      #     - build-for-testing
+      - run-unit-tests:
+        requires:
+          - ios-environment-setup
+        pre-steps:
+          - build-for-testing
       # - run-ui-tests:
       #   requires:
       #     - run-unit-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,8 @@ workflows:
     jobs:
       - ios-environment-setup
       - build-for-testing:
-        requires:
-          - ios-environment-setup
+          requires:
+            - ios-environment-setup
       # - run-unit-tests:
       #   requires:
       #     - build-for-testing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,20 +33,26 @@ jobs:
       - run:
           name: Install Dependencies
           command: .circleci/scripts/install_dependencies.sh
-#      - run:
-#          name: Build for testing
-#          command: xcodebuild build-for-testing
-#            -workspace HGCApp.xcworkspace
-#            -scheme Debug
-#            -configuration Debug
-#            -destination 'platform=iOS Simulator,name=iPhone 8'
-#      - run:
-#          name: Run unit tests
-#          command: xcodebuild test-without-building
-#            -workspace HGCApp.xcworkspace
-#            -scheme Debug
-#            -configuration Debug
-#            -destination 'platform=iOS Simulator,name=iPhone 8'
+  build-for-testing:
+    steps:
+       - run:
+           name: Build for testing
+           command: xcodebuild build-for-testing
+             -workspace HGCApp.xcworkspace
+             -scheme Debug
+             -configuration Debug
+             -destination 'platform=iOS Simulator,name=iPhone 8'
+  run-unit-tests:
+    steps:
+       - run:
+           name: Run unit tests
+           command: xcodebuild test-without-building
+             -workspace HGCApp.xcworkspace
+             -scheme Debug
+             -configuration Debug
+             -destination 'platform=iOS Simulator,name=iPhone 8'
+  build-for-ui-testing:
+    steps:
       - run:
           name: Build for UI testing
           command: xcodebuild build-for-testing
@@ -54,15 +60,16 @@ jobs:
             -scheme Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
             -derivedDataPath build
-      - run:
-          name: Show Contents
-          command: cat build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
+  run-ui-tests:
+    steps:
       - run:
           name: Run OnboardExistingTests
           command: xcodebuild test-without-building
-            -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun 
-            -destination 'platform=iOS Simulator,name=iPhone 8' 
+            -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
+            -destination 'platform=iOS Simulator,name=iPhone 8'
             -only-testing:HGCAppUITests/OnboardExistingTests.swift
+  build-for-running:
+    steps:
       - run:
           name: Build for running
           command: xcodebuild build
@@ -76,3 +83,8 @@ workflows:
   build-and-unit-test:
     jobs:
       - ios-environment-setup
+      - build-for-testing
+      - run-unit-tests
+      - build-for-ui-testing
+      - run-ui-tests
+      - build-for-running

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
       - run:
           name: Run OnboardExistingTests
           command: xcodebuild test-without-building
-            -xctestrun build/Build/Products/Debug_iphonesimulator13.4-x86_64.xctestrun 
+            -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun 
             -destination 'platform=iOS Simulator,name=iPhone 8' 
             -only-testing:HGCAppUITests/OnboardExistingTests.swift
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,18 +48,18 @@ jobs:
             -configuration Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
       - run:
-          name: Build for testing
+          name: Build for UI testing
           command: xcodebuild build-for-testing
             -workspace HGCApp.xcworkspace
             -scheme Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
             -derivedDataPath build
-#     - run:
-#         name: Run OnboardExistingTests
-#         command: xcodebuild test-without-building
-#           -xctestrun build/Build/Products/Debug_iphonesimulator13.4-x86_64.xctestrun 
-#           -destination 'platform=iOS Simulator,name=iPhone 8' 
-#           -only-testing:HGCAppUITests/OnboardExistingTests.swift
+      - run:
+          name: Run OnboardExistingTests
+          command: xcodebuild test-without-building
+            -xctestrun build/Build/Products/Debug_iphonesimulator13.4-x86_64.xctestrun 
+            -destination 'platform=iOS Simulator,name=iPhone 8' 
+            -only-testing:HGCAppUITests/OnboardExistingTests.swift
       - run:
           name: Build for running
           command: xcodebuild build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,8 @@ jobs:
       - persist_to_workspace:
           root: /
           paths:
-            - Users/distiller/
+            - Users/distiller/project/
+            - Users/distiller/Library/
   build-for-testing:
     macos:
       xcode: "11.3.1"
@@ -55,7 +56,8 @@ jobs:
        - persist_to_workspace:
            root: /
            paths:
-             - Users/distiller/
+             - Users/distiller/project/
+             - Users/distiller/Library/
   run-unit-tests:
     macos:
       xcode: "11.3.1"
@@ -74,7 +76,8 @@ jobs:
        - persist_to_workspace:
            root: /
            paths:
-             - Users/distiller/
+             - Users/distiller/project/
+             - Users/distiller/Library/
   build-for-ui-testing:
     macos:
       xcode: "11.3.1"
@@ -93,7 +96,8 @@ jobs:
       - persist_to_workspace:
           root: /
           paths:
-            - Users/distiller/
+            - Users/distiller/project/
+            - Users/distiller/Library/
   run-ui-tests:
     macos:
       xcode: "11.3.1"
@@ -111,15 +115,16 @@ jobs:
       - persist_to_workspace:
           root: /
           paths:
-            - Users/distiller/
+            - Users/distiller/project/
+            - Users/distiller/Library/
   build-for-running:
     macos:
       xcode: "11.3.1"
     environment:
       FL_OUTPUT_DIR: output
     steps:
-      - attach_workspace:
-          at: /
+       - attach_workspace:
+           at: /
       - run:
           name: Build for running
           command: xcodebuild build
@@ -130,7 +135,8 @@ jobs:
       - persist_to_workspace:
           root: /
           paths:
-            - Users/distiller/
+            - Users/distiller/project/
+            - Users/distiller/Library/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,6 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 8'
 
 workflows:
-  version: 2
   build-and-test:
     jobs:
       - ios-environment-setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,18 +103,18 @@ workflows:
   build-and-test:
     jobs:
       - ios-environment-setup
-      # - build-for-testing:
-      #    requires:
-      #      - ios-environment-setup
-      # - run-unit-tests:
-      #    requires:
-      #      - build-for-testing
-      # - build-for-ui-testing:
-      #    requires:
-      #      - run-unit-tests
-      # - run-ui-tests:
-      #    requires:
-      #      - build-for-ui-testing
-      # - build-for-running:
-      #    requires:
-      #      - run-ui-tests
+      - build-for-testing:
+         requires:
+           - ios-environment-setup
+      - run-unit-tests:
+         requires:
+           - build-for-testing
+      - build-for-ui-testing:
+         requires:
+           - run-unit-tests
+      - run-ui-tests:
+         requires:
+           - build-for-ui-testing
+      - build-for-running:
+         requires:
+           - run-ui-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,16 +103,17 @@ workflows:
     jobs:
       - ios-environment-setup
       - build-for-testing:
-          requires:
-            - ios-environment-setup
-      # - run-unit-tests:
-      #   requires:
-      #     - build-for-testing
-      # - run-ui-tests:
-      #   requires:
-      #     - run-unit-tests
-      #   pre-steps:
-      #     - build-for-ui-testing
-      # - build-for-running:
-      #   requires:
-      #     - run-ui-tests
+         requires:
+           - ios-environment-setup
+      - run-unit-tests:
+         requires:
+           - build-for-testing
+      - build-for-ui-testing:
+         requires:
+           - run-unit-tests
+      - run-ui-tests:
+         requires:
+           - build-for-ui-testing
+      - build-for-running:
+         requires:
+           - run-ui-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       # Repository cache
       - restore-cache:
-        keys:
-          - source-v1-{{ .Branch }}-{{ .Revision }}
-          - source-v1-{{ .Branch }}-
-          - source-v1-
+            keys:
+              - source-v1-{{ .Branch }}-{{ .Revision }}
+              - source-v1-{{ .Branch }}-
+              - source-v1-
       - checkout
       - save-cache:
           key: source-v1-{{ .Branch }}-{{ .Revision }}
@@ -45,7 +45,7 @@ jobs:
       FL_OUTPUT_DIR: output
     steps:
       - attach_workspace:
-        at: /
+          at: /
       - run:
           name: Build for testing
           command: xcodebuild build-for-testing
@@ -65,7 +65,7 @@ jobs:
       FL_OUTPUT_DIR: output
     steps:
       - attach_workspace:
-        at: /
+          at: /
       - run:
           name: Run unit tests
           command: xcodebuild test-without-building
@@ -124,14 +124,14 @@ jobs:
       FL_OUTPUT_DIR: output
     steps:
       - attach_workspace:
-        at: /
+          at: /
       - run:
-        name: Build for running
-        command: xcodebuild build
-          -workspace HGCApp.xcworkspace
-          -scheme Debug
-          -configuration Debug
-          -destination 'platform=iOS Simulator,name=iPhone 8'
+          name: Build for running
+          command: xcodebuild build
+            -workspace HGCApp.xcworkspace
+            -scheme Debug
+            -configuration Debug
+            -destination 'platform=iOS Simulator,name=iPhone 8'
       - persist_to_workspace:
           root: /
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             -scheme Debug
             -configuration Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
-	    -derivedDataPath build
+            -derivedDataPath build
       - run:
           name: Run unit tests
           command: xcodebuild test-without-building
@@ -48,12 +48,12 @@ jobs:
             -scheme Debug
             -configuration Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
-#      - run:
-#	  name: Run OnboardExistingTests
-#	  command: xcodebuild test-without-building
+#     - run:
+#         name: Run OnboardExistingTests
+#         command: xcodebuild test-without-building
 #           -xctestrun build/Build/Products/Debug_iphonesimulator13.4-x86_64.xctestrun 
-#	    -destination 'platform=iOS Simulator,name=iPhone 8' 
-#	    -only-testing:HGCAppUITests/OnboardExistingTests.swift
+#           -destination 'platform=iOS Simulator,name=iPhone 8' 
+#           -only-testing:HGCAppUITests/OnboardExistingTests.swift
       - run:
           name: Build for running
           command: xcodebuild build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             -scheme Debug
             -configuration Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
-            -derivedDataPath build
+#            -derivedDataPath build
       - run:
           name: Run unit tests
           command: xcodebuild test-without-building

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
           command: xcodebuild test-without-building
             -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
             -destination 'platform=iOS Simulator,name=iPhone 8'
-            -only-testing HGCAppUITests/OnboardExistingTests/testIdealUserPath
+            -only-testing:HGCAppUITests/OnboardExistingTests.swift
       - persist_to_workspace:
           root: /
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 # .circleci/config.yml
-version: 2.1
+version: 2
 jobs:
   ios-environment-setup:
     macos:
@@ -99,6 +99,7 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 8'
 
 workflows:
+  version: 2
   build-and-test:
     jobs:
       - ios-environment-setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,9 +105,9 @@ workflows:
       - build-for-testing:
         requires:
           - ios-environment-setup
-      - run-unit-tests:
-        requires:
-          - build-for-testing
+      # - run-unit-tests:
+      #   requires:
+      #     - build-for-testing
       # - run-ui-tests:
       #   requires:
       #     - run-unit-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
             -scheme Debug
             -configuration Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
+	    -derivedDataPath build
       - run:
           name: Run unit tests
           command: xcodebuild test-without-building
@@ -47,6 +48,12 @@ jobs:
             -scheme Debug
             -configuration Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
+#      - run:
+#	  name: Run OnboardExistingTests
+#	  command: xcodebuild test-without-building
+#           -xctestrun build/Build/Products/Debug_iphonesimulator13.4-x86_64.xctestrun 
+#	    -destination 'platform=iOS Simulator,name=iPhone 8' 
+#	    -only-testing:HGCAppUITests/OnboardExistingTests.swift
       - run:
           name: Build for running
           command: xcodebuild build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,9 @@ jobs:
       - run:
           name: Run OnboardExistingTests
           command: xcodebuild test-without-building
-            -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
+            -scheme Debug
+            -configuration Debug
+            # -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
             -destination 'platform=iOS Simulator,name=iPhone 8'
             -only-testing HGCAppUITests/OnboardExistingTests/testIdealUserPath
       - persist_to_workspace:
@@ -150,12 +152,13 @@ workflows:
       - run-unit-tests:
          requires:
            - build-for-testing
-      - build-for-ui-testing:
-         requires:
-           - run-unit-tests
+      # - build-for-ui-testing:
+      #    requires:
+      #      - run-unit-tests
       - run-ui-tests:
          requires:
-           - build-for-ui-testing
+           # - build-for-ui-testing
+           - run-unit-tests
       - build-for-running:
          requires:
            - run-ui-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,6 @@ jobs:
       xcode: "11.3.1"
     environment:
       FL_OUTPUT_DIR: output
-    requires:
-      - ios-environment-setup
     steps:
        - run:
            name: Build for testing
@@ -53,8 +51,6 @@ jobs:
       xcode: "11.3.1"
     environment:
       FL_OUTPUT_DIR: output
-    pre-steps:
-      - build-for-testing
     steps:
        - run:
            name: Run unit tests
@@ -68,8 +64,6 @@ jobs:
       xcode: "11.3.1"
     environment:
       FL_OUTPUT_DIR: output
-    requires:
-      - ios-environment-setup
     steps:
       - run:
           name: Build for UI testing
@@ -83,8 +77,6 @@ jobs:
       xcode: "11.3.1"
     environment:
       FL_OUTPUT_DIR: output
-    pre-steps:
-      - build-for-ui-testing
     steps:
       - run:
           name: Run OnboardExistingTests
@@ -97,8 +89,6 @@ jobs:
       xcode: "11.3.1"
     environment:
       FL_OUTPUT_DIR: output
-    requires:
-      - ios-environment-setup
     steps:
       - run:
           name: Build for running
@@ -121,11 +111,10 @@ workflows:
       - run-ui-tests:
         requires:
           - ios-environment-setup
-        pre-steps:
           - run-unit-tests
+        pre-steps:
           - build-for-ui-testing
       - build-for-running:
         requires:
           - ios-environment-setup
-        pre-steps:
           - run-ui-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ jobs:
           name: Install Dependencies
           command: .circleci/scripts/install_dependencies.sh
   build-for-testing:
+    requires:
+      - ios-environment-setup
     steps:
        - run:
            name: Build for testing
@@ -43,6 +45,8 @@ jobs:
              -configuration Debug
              -destination 'platform=iOS Simulator,name=iPhone 8'
   run-unit-tests:
+    pre-steps:
+      - build-for-testing
     steps:
        - run:
            name: Run unit tests
@@ -52,6 +56,8 @@ jobs:
              -configuration Debug
              -destination 'platform=iOS Simulator,name=iPhone 8'
   build-for-ui-testing:
+    requires:
+      - ios-environment-setup
     steps:
       - run:
           name: Build for UI testing
@@ -61,6 +67,8 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 8'
             -derivedDataPath build
   run-ui-tests:
+    pre-steps:
+      - build-for-ui-testing
     steps:
       - run:
           name: Run OnboardExistingTests
@@ -69,6 +77,8 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 8'
             -only-testing:HGCAppUITests/OnboardExistingTests.swift
   build-for-running:
+    requires:
+      - ios-environment-setup
     steps:
       - run:
           name: Build for running
@@ -82,9 +92,6 @@ workflows:
   version: 2
   build-and-unit-test:
     jobs:
-      - ios-environment-setup
-      - build-for-testing
       - run-unit-tests
-      - build-for-ui-testing
       - run-ui-tests
       - build-for-running

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,11 +133,11 @@ jobs:
             -scheme Debug
             -configuration Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
-      - persist_to_workspace:
-          root: /
-          paths:
-            - Users/distiller/project
-            - Users/distiller/Library
+      # - persist_to_workspace:
+      #     root: /
+      #     paths:
+      #       - Users/distiller/project
+      #       - Users/distiller/Library
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,25 @@ jobs:
           paths:
             - Users/distiller/project
             - Users/distiller/Library
+  run-unit-test-tests:
+    macos:
+      xcode: "11.3.1"
+    environment:
+      FL_OUTPUT_DIR: output
+    steps:
+      - attach_workspace:
+          at: /
+      - run:
+          name: Run unit tests
+          command: xcodebuild test-without-building
+            -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
+            -destination 'platform=iOS Simulator,name=iPhone 8'
+            -skip-testing HGCAppUITests/OnboardExistingTests/testIdealUserPath
+      - persist_to_workspace:
+          root: /
+          paths:
+            - Users/distiller/project
+            - Users/distiller/Library
   build-for-running:
     macos:
       xcode: "11.3.1"
@@ -133,29 +152,32 @@ jobs:
             -scheme Debug
             -configuration Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
-      - persist_to_workspace:
-          root: /
-          paths:
-            - Users/distiller/project
-            - Users/distiller/Library
+      # - persist_to_workspace:
+      #     root: /
+      #     paths:
+      #       - Users/distiller/project
+      #       - Users/distiller/Library
 
 workflows:
   version: 2
   build-and-test:
     jobs:
       - ios-environment-setup
-      - build-for-testing:
-         requires:
-           - ios-environment-setup
-      - run-unit-tests:
-         requires:
-           - build-for-testing
+      # - build-for-testing:
+      #    requires:
+      #      - ios-environment-setup
+      # - run-unit-tests:
+      #    requires:
+      #      - build-for-testing
       - build-for-ui-testing:
          requires:
-           - run-unit-tests
+           - ios-environment-setup
       - run-ui-tests:
          requires:
            - build-for-ui-testing
-      - build-for-running:
+      -run-unit-test-tests:
          requires:
            - run-ui-tests
+      - build-for-running:
+         requires:
+           - run-unit-test-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
           paths:
             - Users/distiller/project
             - Users/distiller/Library
-  run-unit-test-tests:
+  run-unit-tests:
     macos:
       xcode: "11.3.1"
     environment:
@@ -128,9 +128,9 @@ workflows:
       - run-ui-tests:
          requires:
            - build-for-ui-testing
-      - run-unit-test-tests:
+      - run-unit-tests:
          requires:
            - run-ui-tests
       - build-for-running:
          requires:
-           - run-unit-test-tests
+           - run-unit-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,8 @@ jobs:
       - persist_to_workspace:
           root: /
           paths:
-            - Users/distiller/project/
-            - Users/distiller/Library/
+            - Users/distiller/project
+            - Users/distiller/Library
   build-for-testing:
     macos:
       xcode: "11.3.1"
@@ -56,8 +56,8 @@ jobs:
        - persist_to_workspace:
            root: /
            paths:
-             - Users/distiller/project/
-             - Users/distiller/Library/
+             - Users/distiller/project
+             - Users/distiller/Library
   run-unit-tests:
     macos:
       xcode: "11.3.1"
@@ -76,8 +76,8 @@ jobs:
        - persist_to_workspace:
            root: /
            paths:
-             - Users/distiller/project/
-             - Users/distiller/Library/
+             - Users/distiller/project
+             - Users/distiller/Library
   build-for-ui-testing:
     macos:
       xcode: "11.3.1"
@@ -96,8 +96,8 @@ jobs:
       - persist_to_workspace:
           root: /
           paths:
-            - Users/distiller/project/
-            - Users/distiller/Library/
+            - Users/distiller/project
+            - Users/distiller/Library
   run-ui-tests:
     macos:
       xcode: "11.3.1"
@@ -115,8 +115,8 @@ jobs:
       - persist_to_workspace:
           root: /
           paths:
-            - Users/distiller/project/
-            - Users/distiller/Library/
+            - Users/distiller/project
+            - Users/distiller/Library
   build-for-running:
     macos:
       xcode: "11.3.1"
@@ -135,8 +135,8 @@ jobs:
       - persist_to_workspace:
           root: /
           paths:
-            - Users/distiller/project/
-            - Users/distiller/Library/
+            - Users/distiller/project
+            - Users/distiller/Library
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ workflows:
       - run-ui-tests:
          requires:
            - build-for-ui-testing
-      -run-unit-test-tests:
+      - run-unit-test-tests:
          requires:
            - run-ui-tests
       - build-for-running:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,8 @@ jobs:
     environment:
       FL_OUTPUT_DIR: output
     steps:
+       - attach_workspace:
+           at: /
        - run:
            name: Build for testing
            command: xcodebuild build-for-testing
@@ -60,6 +62,8 @@ jobs:
     environment:
       FL_OUTPUT_DIR: output
     steps:
+       - attach_workspace:
+           at: /
        - run:
            name: Run unit tests
            command: xcodebuild test-without-building
@@ -77,6 +81,8 @@ jobs:
     environment:
       FL_OUTPUT_DIR: output
     steps:
+      - attach_workspace:
+          at: /
       - run:
           name: Build for UI testing
           command: xcodebuild build-for-testing
@@ -94,6 +100,8 @@ jobs:
     environment:
       FL_OUTPUT_DIR: output
     steps:
+      - attach_workspace:
+          at: /
       - run:
           name: Run OnboardExistingTests
           command: xcodebuild test-without-building
@@ -110,6 +118,8 @@ jobs:
     environment:
       FL_OUTPUT_DIR: output
     steps:
+      - attach_workspace:
+          at: /
       - run:
           name: Build for running
           command: xcodebuild build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       # Repository cache
       - restore-cache:
-          keys:
-            - source-v1-{{ .Branch }}-{{ .Revision }}
-            - source-v1-{{ .Branch }}-
-            - source-v1-
+        keys:
+          - source-v1-{{ .Branch }}-{{ .Revision }}
+          - source-v1-{{ .Branch }}-
+          - source-v1-
       - checkout
       - save-cache:
           key: source-v1-{{ .Branch }}-{{ .Revision }}
@@ -44,40 +44,40 @@ jobs:
     environment:
       FL_OUTPUT_DIR: output
     steps:
-       - attach_workspace:
-           at: /
-       - run:
-           name: Build for testing
-           command: xcodebuild build-for-testing
-             -workspace HGCApp.xcworkspace
-             -scheme Debug
-             -configuration Debug
-             -destination 'platform=iOS Simulator,name=iPhone 8'
-       - persist_to_workspace:
-           root: /
-           paths:
-             - Users/distiller/project
-             - Users/distiller/Library
+      - attach_workspace:
+        at: /
+      - run:
+        name: Build for testing
+        command: xcodebuild build-for-testing
+          -workspace HGCApp.xcworkspace
+          -scheme Debug
+          -configuration Debug
+          -destination 'platform=iOS Simulator,name=iPhone 8'
+      - persist_to_workspace:
+        root: /
+        paths:
+          - Users/distiller/project
+          - Users/distiller/Library
   run-unit-tests:
     macos:
       xcode: "11.3.1"
     environment:
       FL_OUTPUT_DIR: output
     steps:
-       - attach_workspace:
-           at: /
-       - run:
-           name: Run unit tests
-           command: xcodebuild test-without-building
-             -workspace HGCApp.xcworkspace
-             -scheme Debug
-             -configuration Debug
-             -destination 'platform=iOS Simulator,name=iPhone 8'
-       - persist_to_workspace:
-           root: /
-           paths:
-             - Users/distiller/project
-             - Users/distiller/Library
+      - attach_workspace:
+        at: /
+      - run:
+        name: Run unit tests
+        command: xcodebuild test-without-building
+          -workspace HGCApp.xcworkspace
+          -scheme Debug
+          -configuration Debug
+          -destination 'platform=iOS Simulator,name=iPhone 8'
+      - persist_to_workspace:
+        root: /
+        paths:
+          - Users/distiller/project
+          - Users/distiller/Library
   build-for-ui-testing:
     macos:
       xcode: "11.3.1"
@@ -87,17 +87,17 @@ jobs:
       - attach_workspace:
           at: /
       - run:
-          name: Build for UI testing
-          command: xcodebuild build-for-testing
-            -workspace HGCApp.xcworkspace
-            -scheme Debug
-            -destination 'platform=iOS Simulator,name=iPhone 8'
-            -derivedDataPath build
+        name: Build for UI testing
+        command: xcodebuild build-for-testing
+          -workspace HGCApp.xcworkspace
+          -scheme Debug
+          -destination 'platform=iOS Simulator,name=iPhone 8'
+          -derivedDataPath build
       - persist_to_workspace:
-          root: /
-          paths:
-            - Users/distiller/project
-            - Users/distiller/Library
+        root: /
+        paths:
+          - Users/distiller/project
+          - Users/distiller/Library
   run-ui-tests:
     macos:
       xcode: "11.3.1"
@@ -107,36 +107,36 @@ jobs:
       - attach_workspace:
           at: /
       - run:
-          name: Run OnboardExistingTests
-          command: xcodebuild test-without-building
-            -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
-            -destination 'platform=iOS Simulator,name=iPhone 8'
-            -only-testing:HGCAppUITests/OnboardExistingTests.swift
+        name: Run OnboardExistingTests
+        command: xcodebuild test-without-building
+          -xctestrun build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
+          -destination 'platform=iOS Simulator,name=iPhone 8'
+          -only-testing:HGCAppUITests/OnboardExistingTests.swift
       - persist_to_workspace:
-          root: /
-          paths:
-            - Users/distiller/project
-            - Users/distiller/Library
+        root: /
+        paths:
+          - Users/distiller/project
+          - Users/distiller/Library
   build-for-running:
     macos:
       xcode: "11.3.1"
     environment:
       FL_OUTPUT_DIR: output
     steps:
-       - attach_workspace:
-           at: /
+      - attach_workspace:
+        at: /
       - run:
-          name: Build for running
-          command: xcodebuild build
-            -workspace HGCApp.xcworkspace
-            -scheme Debug
-            -configuration Debug
-            -destination 'platform=iOS Simulator,name=iPhone 8'
+        name: Build for running
+        command: xcodebuild build
+          -workspace HGCApp.xcworkspace
+          -scheme Debug
+          -configuration Debug
+          -destination 'platform=iOS Simulator,name=iPhone 8'
       - persist_to_workspace:
-          root: /
-          paths:
-            - Users/distiller/project
-            - Users/distiller/Library
+        root: /
+        paths:
+          - Users/distiller/project
+          - Users/distiller/Library
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,8 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 8'
             -derivedDataPath build
       - run:
-          name: List Contents
-          command: ls -lrt build/Build/Products/
+          name: Show Contents
+          command: cat build/Build/Products/Debug_iphonesimulator13.2-x86_64.xctestrun
       - run:
           name: Run OnboardExistingTests
           command: xcodebuild test-without-building

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,6 @@ jobs:
             -scheme Debug
             -configuration Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
-#            -derivedDataPath build
       - run:
           name: Run unit tests
           command: xcodebuild test-without-building
@@ -48,6 +47,13 @@ jobs:
             -scheme Debug
             -configuration Debug
             -destination 'platform=iOS Simulator,name=iPhone 8'
+      - run:
+          name: Build for testing
+          command: xcodebuild build-for-testing
+            -workspace HGCApp.xcworkspace
+            -scheme Debug
+            -destination 'platform=iOS Simulator,name=iPhone 8'
+            -derivedDataPath build
 #     - run:
 #         name: Run OnboardExistingTests
 #         command: xcodebuild test-without-building

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - persist_to_workspace:
           root: /
           paths:
-            - Users/distiller/project/
+            - Users/distiller/
   build-for-testing:
     macos:
       xcode: "11.3.1"
@@ -55,7 +55,7 @@ jobs:
        - persist_to_workspace:
            root: /
            paths:
-             - Users/distiller/project/
+             - Users/distiller/
   run-unit-tests:
     macos:
       xcode: "11.3.1"
@@ -74,7 +74,7 @@ jobs:
        - persist_to_workspace:
            root: /
            paths:
-             - Users/distiller/project/
+             - Users/distiller/
   build-for-ui-testing:
     macos:
       xcode: "11.3.1"
@@ -93,7 +93,7 @@ jobs:
       - persist_to_workspace:
           root: /
           paths:
-            - Users/distiller/project/
+            - Users/distiller/
   run-ui-tests:
     macos:
       xcode: "11.3.1"
@@ -111,7 +111,7 @@ jobs:
       - persist_to_workspace:
           root: /
           paths:
-            - Users/distiller/project/
+            - Users/distiller/
   build-for-running:
     macos:
       xcode: "11.3.1"
@@ -130,7 +130,7 @@ jobs:
       - persist_to_workspace:
           root: /
           paths:
-            - Users/distiller/project/
+            - Users/distiller/
 
 workflows:
   version: 2

--- a/HGCApp.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
+++ b/HGCApp.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
@@ -21,7 +21,7 @@
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
-            buildForTesting = "NO"
+            buildForTesting = "YES"
             buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
@@ -87,6 +87,16 @@
                </Test>
             </SkippedTests>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "35B8ABD81F9E5642003E4F57"
+               BuildableName = "HGCAppUITests.xctest"
+               BlueprintName = "HGCAppUITests"
+               ReferencedContainer = "container:HGCApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -110,6 +120,23 @@
             ReferencedContainer = "container:HGCApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "EXISTING_ACCOUNT_ID"
+            value = "0.0.39128"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "EXISTING_ACCOUNT_PUBLIC_KEY"
+            value = "447dc6bdbfc64eb894851825194744662afcb70efb8b23a6a24af98f0c1fd8ad"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "EXISTING_ACCOUNT_RECOVERY_PHRASE"
+            value = "girl adjust asset interest razor thrive joy diet stock radar home because sausage culture fitness damage vicious target cabin best stomach replace example ordinary"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -127,6 +154,23 @@
             ReferencedContainer = "container:HGCApp.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "EXISTING_ACCOUNT_RECOVERY_PHRASE"
+            value = "girl adjust asset interest razor thrive joy diet stock radar home because sausage culture fitness damage vicious target cabin best stomach replace example ordinary"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "EXISTING_ACCOUNT_ID"
+            value = "0.0.39128"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "EXISTING_ACCOUNT_PUBLIC_KEY"
+            value = "447dc6bdbfc64eb894851825194744662afcb70efb8b23a6a24af98f0c1fd8ad"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/HGCApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HGCApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -38,7 +38,7 @@
         }
       },
       {
-        "package": "GRPC",
+        "package": "grpc-swift",
         "repositoryURL": "https://github.com/grpc/grpc-swift.git",
         "state": {
           "branch": "nio",

--- a/HGCApp/Supporting Files/nodes-testnet.json
+++ b/HGCApp/Supporting Files/nodes-testnet.json
@@ -1,27 +1,27 @@
 [
     {
-        "host": "0.testnet.hedera.com",
+        "host": "34.94.106.61",
         "port": 50211,
         "accountNum": 3,
         "shardNum": 0,
         "realmNum": 0
     },
     {
-        "host": "1.testnet.hedera.com",
+        "host": "35.237.119.55",
         "port": 50211,
         "accountNum": 4,
         "shardNum": 0,
         "realmNum": 0
     },
     {
-        "host": "2.testnet.hedera.com",
+        "host": "35.245.27.193",
         "port": 50211,
         "accountNum": 5,
         "shardNum": 0,
         "realmNum": 0
     },
     {
-        "host": "3.testnet.hedera.com",
+        "host": "34.83.112.116",
         "port": 50211,
         "accountNum": 6,
         "shardNum": 0,

--- a/tests/HGCAppUITests/OnboardExistingTests.swift
+++ b/tests/HGCAppUITests/OnboardExistingTests.swift
@@ -210,6 +210,7 @@ class OnboardExistingTests: XCTestCase {
             nextButton.tap()
         }
 
+        sleep(20)
         // Steps on Wallet Restored Successfully alert.
         do {
             // Validation: confirm there is an alert


### PR DESCRIPTION
Fixes - https://github.com/hashgraph/hedera-wallet-ios/issues/204
To Add UI test in circleCI testing. 

Step 1- add derivedDataPath to build arguments which will create xctestrun file

Step 2- add UI test job into CI config


We had to do UI test first and then unit tests as UI tests fails if there is any context already present before the app starts. 

Also enabled UI tests in Debug configuration so that when we do build-for-testing that test will be added to the generated xctestrun which can be used to run specific tests.